### PR TITLE
Fix documentation error

### DIFF
--- a/lib/mongo/update.js
+++ b/lib/mongo/update.js
@@ -137,7 +137,7 @@ class Update {
 
   /**
    * Sets the value of a field to current timestamp.
-   * @param {Object} obj - The object containing fields to set.
+   * @param {...string} values - The fields to set.
    * @example
    * db.update('posts').currentTimestamp('lastModified').all().then(res => ...)
    */
@@ -150,7 +150,7 @@ class Update {
 
   /**
    * Sets the value of a field to current date.
-   * @param {Object} obj - The object containing fields to set.
+   * @param {...string} values - The fields to set.
    * @example
    * db.update('posts').currentDate('lastModified').all().then(res => ...)
    */


### PR DESCRIPTION
Also, https://github.com/spaceuptech/space-api-js/blob/9f9ae97d02ef467343d1dec50908456d85ceafa0/lib/mongo/aggregate.js#L19   
Contanins `many()`, which should be `all()`.