### PR TITLE
fix: add missing `var` keyword to generateFind `or` case

### DIFF
--- a/lib/mongo/mongo.js
+++ b/lib/mongo/mongo.js
@@ -273,7 +273,7 @@ const generateFind = (condition) => {
       return condition.clauses.reduce((prev, curr) => Object.assign({}, prev, generateFind(curr)), {})
 
     case 'or':
-      newConds = condition.clauses.map(cond => generateFind(cond))
+      var newConds = condition.clauses.map(cond => generateFind(cond))
       return { '$or': newConds }
 
     case 'cond':

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-api",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Calling `or` method from api results in an error
```
mongo.js:388 Uncaught ReferenceError: newConds is not defined
```